### PR TITLE
:bug: #56 合計行の書式設定処理を共通処理から外す

### DIFF
--- a/functions/update_ability_sheet/app.py
+++ b/functions/update_ability_sheet/app.py
@@ -14,9 +14,12 @@ from my_modules.constants.spread_sheet import (
     EXP_HEADER_TEXT,
     FAITH_HEADER_TEXT,
     HORIZONTAL_ALIGNMENT_CENTER,
+    HORIZONTAL_ALIGNMENT_RIGHT,
     LEVEL_HEADER_TEXT,
     NO_HEADER_TEXT,
     PLAYER_CHARACTER_NAME_HEADER_TEXT,
+    TOTAL_COLUMN_INDEX,
+    TOTAL_TEXT,
 )
 from my_modules.constants.sword_world import COMBAT_SKILLS
 from my_modules.spreadsheet.my_worksheet import (
@@ -174,6 +177,7 @@ def updateAbilitySheet(
     # 合計行
     notSkillColumnCount: int = len(headers) - len(COMBAT_SKILLS)
     total: list = [None] * notSkillColumnCount
+    total[TOTAL_COLUMN_INDEX] = TOTAL_TEXT
     for combatSkill in COMBAT_SKILLS.values():
         total.append(
             sum(
@@ -200,13 +204,24 @@ def updateAbilitySheet(
     )
 
     # アクティブ
+    updateDataCount: int = len(updateData)
     activeCountIndex: int = headers.index(ACTIVE_HEADER_TEXT)
     startA1 = rowcol_to_a1(2, activeCountIndex + 1)
-    endA1 = rowcol_to_a1(len(updateData) - 1, activeCountIndex + 1)
+    endA1 = rowcol_to_a1(updateDataCount - 1, activeCountIndex + 1)
     formats.append(
         {
             "range": f"{startA1}:{endA1}",
             "format": HORIZONTAL_ALIGNMENT_CENTER,
+        }
+    )
+
+    # 合計行
+    startA1 = rowcol_to_a1(updateDataCount, notSkillColumnCount + 1)
+    endA1 = rowcol_to_a1(updateDataCount, len(headers))
+    formats.append(
+        {
+            "range": f"{startA1}:{endA1}",
+            "format": HORIZONTAL_ALIGNMENT_RIGHT,
         }
     )
 

--- a/functions/update_abyss_curse_sheet/app.py
+++ b/functions/update_abyss_curse_sheet/app.py
@@ -12,8 +12,11 @@ from my_modules.constants.spread_sheet import (
     ACTIVE_HEADER_TEXT,
     DEFAULT_TEXT_FORMAT,
     HORIZONTAL_ALIGNMENT_CENTER,
+    HORIZONTAL_ALIGNMENT_RIGHT,
     NO_HEADER_TEXT,
     PLAYER_CHARACTER_NAME_HEADER_TEXT,
+    TOTAL_COLUMN_INDEX,
+    TOTAL_TEXT,
     TRUE_STRING,
 )
 from my_modules.constants.sword_world import ABYSS_CURSES
@@ -135,6 +138,7 @@ def updateAbyssCurseSheet(
     # 合計行
     notTotalColumnCount: int = len(headers) - len(ABYSS_CURSES) - 1
     total: list = [None] * notTotalColumnCount
+    total[TOTAL_COLUMN_INDEX] = TOTAL_TEXT
 
     # アビスカースの数
     total.append(
@@ -173,6 +177,16 @@ def updateAbyssCurseSheet(
         {
             "range": f"{startA1}:{endA1}",
             "format": HORIZONTAL_ALIGNMENT_CENTER,
+        }
+    )
+
+    # 合計行
+    startA1 = rowcol_to_a1(updateDataCount, notTotalColumnCount + 1)
+    endA1 = rowcol_to_a1(updateDataCount, len(headers))
+    formats.append(
+        {
+            "range": f"{startA1}:{endA1}",
+            "format": HORIZONTAL_ALIGNMENT_RIGHT,
         }
     )
 

--- a/functions/update_basic_sheet/app.py
+++ b/functions/update_basic_sheet/app.py
@@ -15,13 +15,16 @@ from my_modules.constants.spread_sheet import (
     FAITH_HEADER_TEXT,
     GAME_MASTER_COUNT_HEADER_TEXT,
     HORIZONTAL_ALIGNMENT_CENTER,
+    HORIZONTAL_ALIGNMENT_RIGHT,
     NO_HEADER_TEXT,
     NUMBER_FORMAT_TYPE_DATE_TIME,
     PLAYER_CHARACTER_NAME_HEADER_TEXT,
     PLAYER_COUNT_HEADER_TEXT,
     PLAYER_NAME_HEADER_TEXT,
     RACE_HEADER_TEXT,
+    TOTAL_COLUMN_INDEX,
     TOTAL_GAME_COUNT_HEADER_TEXT,
+    TOTAL_TEXT,
     TRUE_STRING,
     UPDATE_DATETIME_HEADER_TEXT,
     VAGRANTS_HEADER_TEXT,
@@ -185,6 +188,7 @@ def updateBasicSheet(
     # 合計行
     total: list = [None] * len(header)
     activeCountIndex: int = header.index(ACTIVE_HEADER_TEXT)
+    total[TOTAL_COLUMN_INDEX] = TOTAL_TEXT
 
     # アクティブ
     total[activeCountIndex] = sum(
@@ -192,17 +196,19 @@ def updateBasicSheet(
     )
 
     # ヴァグランツ
-    vagrantsCountIndex: int = header.index(VAGRANTS_HEADER_TEXT)
-    total[vagrantsCountIndex] = sum(
+    vagrantsIndex: int = header.index(VAGRANTS_HEADER_TEXT)
+    total[vagrantsIndex] = sum(
         x.CountVagrantsPlayerCharacters() for x in players
     )
 
     # 死亡回数
-    total[header.index(DIED_TIMES_HEADER_TEXT)] = sum(
+    diedIndex: int = header.index(DIED_TIMES_HEADER_TEXT)
+    total[diedIndex] = sum(
         sum(y.DiedTimes for y in x.Characters) for x in players
     )
     updateData.append(total)
 
+    # 書式設定
     # アクティブ
     updateDataCount: int = len(updateData)
     startA1: str = rowcol_to_a1(2, activeCountIndex + 1)
@@ -215,8 +221,8 @@ def updateBasicSheet(
     )
 
     # ヴァグランツ
-    startA1 = rowcol_to_a1(2, vagrantsCountIndex + 1)
-    endA1: str = rowcol_to_a1(updateDataCount - 1, vagrantsCountIndex + 1)
+    startA1 = rowcol_to_a1(2, vagrantsIndex + 1)
+    endA1: str = rowcol_to_a1(updateDataCount - 1, vagrantsIndex + 1)
     formats.append(
         {
             "range": f"{startA1}:{endA1}",
@@ -232,6 +238,36 @@ def updateBasicSheet(
         {
             "range": f"{startA1}:{endA1}",
             "format": NUMBER_FORMAT_TYPE_DATE_TIME,
+        }
+    )
+
+    # アクティブ合計
+    startA1 = rowcol_to_a1(updateDataCount, activeCountIndex + 1)
+    endA1 = rowcol_to_a1(updateDataCount, activeCountIndex + 1)
+    formats.append(
+        {
+            "range": f"{startA1}:{endA1}",
+            "format": HORIZONTAL_ALIGNMENT_RIGHT,
+        }
+    )
+
+    # ヴァグランツ合計
+    startA1 = rowcol_to_a1(updateDataCount, vagrantsIndex + 1)
+    endA1 = rowcol_to_a1(updateDataCount, vagrantsIndex + 1)
+    formats.append(
+        {
+            "range": f"{startA1}:{endA1}",
+            "format": HORIZONTAL_ALIGNMENT_RIGHT,
+        }
+    )
+
+    # 死亡合計
+    startA1 = rowcol_to_a1(updateDataCount, diedIndex + 1)
+    endA1 = rowcol_to_a1(updateDataCount, diedIndex + 1)
+    formats.append(
+        {
+            "range": f"{startA1}:{endA1}",
+            "format": HORIZONTAL_ALIGNMENT_RIGHT,
         }
     )
 

--- a/functions/update_general_skill_sheet/app.py
+++ b/functions/update_general_skill_sheet/app.py
@@ -12,8 +12,11 @@ from my_modules.constants.spread_sheet import (
     ACTIVE_HEADER_TEXT,
     DEFAULT_TEXT_FORMAT,
     HORIZONTAL_ALIGNMENT_CENTER,
+    HORIZONTAL_ALIGNMENT_RIGHT,
     NO_HEADER_TEXT,
     PLAYER_CHARACTER_NAME_HEADER_TEXT,
+    TOTAL_COLUMN_INDEX,
+    TOTAL_TEXT,
 )
 from my_modules.constants.sword_world import OFFICIAL_GENERAL_SKILLS
 from my_modules.spreadsheet.my_worksheet import (
@@ -173,6 +176,7 @@ def updateGeneralSkillSheet(
     # 合計行
     notTotalColumnCount: int = len(headers) - len(OFFICIAL_GENERAL_SKILLS)
     total: list = [None] * notTotalColumnCount
+    total[TOTAL_COLUMN_INDEX] = TOTAL_TEXT
     for officialGeneralSkill in OFFICIAL_GENERAL_SKILLS:
         total.append(
             sum(
@@ -202,13 +206,24 @@ def updateGeneralSkillSheet(
     )
 
     # アクティブ
+    updateDataCount: int = len(updateData)
     activeCountIndex: int = headers.index(ACTIVE_HEADER_TEXT)
     startA1 = rowcol_to_a1(2, activeCountIndex + 1)
-    endA1 = rowcol_to_a1(len(updateData) - 1, activeCountIndex + 1)
+    endA1 = rowcol_to_a1(updateDataCount - 1, activeCountIndex + 1)
     formats.append(
         {
             "range": f"{startA1}:{endA1}",
             "format": HORIZONTAL_ALIGNMENT_CENTER,
+        }
+    )
+
+    # 合計行
+    startA1 = rowcol_to_a1(updateDataCount, notTotalColumnCount + 1)
+    endA1 = rowcol_to_a1(updateDataCount, len(headers))
+    formats.append(
+        {
+            "range": f"{startA1}:{endA1}",
+            "format": HORIZONTAL_ALIGNMENT_RIGHT,
         }
     )
 

--- a/functions/update_honor_sheet/app.py
+++ b/functions/update_honor_sheet/app.py
@@ -12,8 +12,11 @@ from my_modules.constants.spread_sheet import (
     ACTIVE_HEADER_TEXT,
     DEFAULT_TEXT_FORMAT,
     HORIZONTAL_ALIGNMENT_CENTER,
+    HORIZONTAL_ALIGNMENT_RIGHT,
     NO_HEADER_TEXT,
     PLAYER_CHARACTER_NAME_HEADER_TEXT,
+    TOTAL_COLUMN_INDEX,
+    TOTAL_TEXT,
     TRUE_STRING,
 )
 from my_modules.constants.sword_world import STYLES
@@ -149,6 +152,7 @@ def updateHonorSheet(
     # 合計行
     notTotalColumnCount: int = len(headers) - len(STYLES) - 1
     total: list = [None] * notTotalColumnCount
+    total[TOTAL_COLUMN_INDEX] = TOTAL_TEXT
 
     # 2.0流派所持
     total.append(
@@ -199,6 +203,16 @@ def updateHonorSheet(
         {
             "range": f"{startA1}:{endA1}",
             "format": HORIZONTAL_ALIGNMENT_CENTER,
+        }
+    )
+
+    # 合計行
+    startA1 = rowcol_to_a1(updateDataCount, notTotalColumnCount + 1)
+    endA1 = rowcol_to_a1(updateDataCount, len(headers))
+    formats.append(
+        {
+            "range": f"{startA1}:{endA1}",
+            "format": HORIZONTAL_ALIGNMENT_RIGHT,
         }
     )
 

--- a/functions/update_player_sheet/app.py
+++ b/functions/update_player_sheet/app.py
@@ -13,12 +13,15 @@ from my_modules.constants.spread_sheet import (
     DEFAULT_TEXT_FORMAT,
     GAME_MASTER_COUNT_HEADER_TEXT,
     HORIZONTAL_ALIGNMENT_CENTER,
+    HORIZONTAL_ALIGNMENT_RIGHT,
     NO_HEADER_TEXT,
     NUMBER_FORMAT_TYPE_DATE_TIME,
     NUMBER_FORMAT_TYPE_INTEGER,
     PLAYER_COUNT_HEADER_TEXT,
     PLAYER_NAME_HEADER_TEXT,
+    TOTAL_COLUMN_INDEX,
     TOTAL_GAME_COUNT_HEADER_TEXT,
+    TOTAL_TEXT,
     TRUE_STRING,
     UPDATE_DATETIME_HEADER_TEXT,
 )
@@ -147,6 +150,7 @@ def updatePlayerSheet(
     # 合計行
     total: list = [None] * len(header)
     activeCountIndex: int = header.index(ACTIVE_HEADER_TEXT)
+    total[TOTAL_COLUMN_INDEX] = TOTAL_TEXT
 
     # アクティブ
     total[activeCountIndex] = sum(
@@ -191,6 +195,16 @@ def updatePlayerSheet(
         {
             "range": f"{startA1}:{endA1}",
             "format": NUMBER_FORMAT_TYPE_DATE_TIME,
+        }
+    )
+
+    # 合計行
+    startA1 = rowcol_to_a1(updateDataCount, activeCountIndex + 1)
+    endA1 = rowcol_to_a1(updateDataCount, activeCountIndex + 1)
+    formats.append(
+        {
+            "range": f"{startA1}:{endA1}",
+            "format": HORIZONTAL_ALIGNMENT_RIGHT,
         }
     )
 

--- a/layers/my_modules/constants/spread_sheet.py
+++ b/layers/my_modules/constants/spread_sheet.py
@@ -45,3 +45,7 @@ DICE_AVERAGE_HEADER_TEXT: str = "ﾀﾞｲｽ平均"
 ADVENTURER_BIRTH_HEADER_TEXT: str = "冒険者\n生まれ"
 BATTLE_DANCER_HEADER_TEXT: str = "バトルダンサー"
 LEVEL_HEADER_TEXT: str = "Lv."
+
+# 合計行のラベル用
+TOTAL_TEXT: str = "合計"
+TOTAL_COLUMN_INDEX: int = 1

--- a/layers/my_modules/spreadsheet/my_worksheet.py
+++ b/layers/my_modules/spreadsheet/my_worksheet.py
@@ -15,7 +15,6 @@ from ..constants.spread_sheet import (
     API_RETRY_WAIT_SECOND,
     DEFAULT_TEXT_FORMAT,
     HORIZONTAL_ALIGNMENT_CENTER,
-    HORIZONTAL_ALIGNMENT_RIGHT,
 )
 from .my_spreadsheet import MySpreadsheet
 
@@ -56,14 +55,14 @@ class MyWorksheet:
     )
     def Update(
         self,
-        originalValues: list[list],
+        values: list[list],
         additionalFormats: list[CellFormat],
         isContainTotalRow: bool,
     ):
         """更新する
 
         Args:
-            originalValues (list[list]): 更新する値
+            values (list[list]): 更新する値
             additionalFormats (list[CellFormat]): 書式
             isContainTotalRow (bool): 合計行を含むか
         """
@@ -71,36 +70,18 @@ class MyWorksheet:
         self.worksheet.clear()
         self.worksheet.clear_basic_filter()
 
-        rowCount: int = len(originalValues)
-        columnCount: int = max(map(lambda x: len(x), originalValues))
-        values: list[list] = originalValues
-        filterLastRowIndex: int = rowCount
-        formats: list[CellFormat] = []
-        if isContainTotalRow:
-            # 合計行のラベル
-            values[-1][1] = "合計"
-
-            # 合計行の数値の書式設定
-            startA1: str = rowcol_to_a1(len(values), 3)
-            endA1: str = rowcol_to_a1(len(values), columnCount)
-            formats.append(
-                {
-                    "range": f"{startA1}:{endA1}",
-                    "format": HORIZONTAL_ALIGNMENT_RIGHT,
-                }
-            )
-
-            # 合計行はフィルターしない
-            filterLastRowIndex -= 1
-
         # 更新
         self.worksheet.update(
             values, value_input_option=ValueInputOption.user_entered
         )
 
+        formats: list[CellFormat] = []
+        rowCount: int = len(values)
+        columnCount: int = max(map(lambda x: len(x), values))
+
         # デフォルトの書式設定
-        startA1 = rowcol_to_a1(1, 1)
-        endA1 = rowcol_to_a1(rowCount, columnCount)
+        startA1: str = rowcol_to_a1(1, 1)
+        endA1: str = rowcol_to_a1(rowCount, columnCount)
         formats.append(
             {
                 "range": f"{startA1}:{endA1}",
@@ -135,7 +116,8 @@ class MyWorksheet:
         self.worksheet.set_basic_filter(
             1,
             1,
-            filterLastRowIndex,
+            rowCount
+            - (1 if isContainTotalRow else 0),  # 合計行はフィルターしない
             columnCount,
         )
 


### PR DESCRIPTION
# Pull request

close #56

# 概要

合計行全体に書式を設定するとPC追加時に困るので、各シートごとの処理で適当に行う

# 詳細

- 共通処理から合計行のフォーマットを削除
- 各画面で合計行のフォーマットを実装

# その他
